### PR TITLE
getGroupsByMember getter and parent getters

### DIFF
--- a/agents/getters/getAgents.js
+++ b/agents/getters/getAgents.js
@@ -5,6 +5,7 @@ const getCredentialByAgent = require('../../credentials/getters/getCredentialByA
 const getProfileByAgent = require('../../profiles/getters/getProfileByAgent')
 const getRawAgents = require('./getRawAgents')
 const getMembersByGroup = require('./getMembersByGroup')
+const getGroupsByMember = require('./getGroupsByMember')
 
 const propOrEmptyArray = propOr([])
 
@@ -13,10 +14,10 @@ module.exports = createSelector(
   getProfileByAgent,
   getMembersByGroup,
   getRawAgents,
-  (credentialByAgent, profileByAgent, membersByGroup, rawAgents) => {
-    const mapMembers = map(member => {
-      const { agentId } = member
-      return merge(member, {
+  (credentialByAgent, profileByAgent, membersByGroup, groupsByMember, rawAgents) => {
+    const mapAgentRelationships = map(agent => {
+      const { agentId } = agent
+      return merge(agent, {
         agent: merge(rawAgents[agentId], {
           id: agentId,
           credential: credentialByAgent[agentId],
@@ -27,10 +28,12 @@ module.exports = createSelector(
 
     const mapAgents = map(agent => {
       const members = propOrEmptyArray(agent.id, membersByGroup)
+      const groups = propOrEmptyArray(agent.id, groupsByMember)
       return merge(agent, {
         credential: credentialByAgent[agent.id],
         profile: profileByAgent[agent.id],
-        members: mapMembers(members)
+        members: mapAgentRelationships(members),
+        groups: mapAgentRelationships(groups)
       })
     })
 

--- a/agents/getters/getGroupsByMember.js
+++ b/agents/getters/getGroupsByMember.js
@@ -1,17 +1,17 @@
 const { pipe, toPairs, map, filter, reduce  } = require('ramda')
 const { createSelector } = require('reselect')
 
-const getRolesBySourceTarget = require('../../relationships/getters/getRolesBySourceTarget')
+const getRolesByTargetSource = require('../../relationships/getters/getRolesByTargetSource')
 
 module.exports = createSelector(
-  getRolesBySourceTarget,
+  getRolesByTargetSource,
   map(pipe(
     toPairs,
     filter(([targetId, roles]) => roles.member),
     reduce((sofar, [targetId, roles]) =>  {
       const agentId = parseInt(targetId)
-      const member = { agentId, roles }
-      return [...sofar, member]
+      const group = { agentId, roles }
+      return [...sofar, group]
     }, [])
   ))
 )

--- a/relationships/getters/getRelationshipsByTargetSourceType.js
+++ b/relationships/getters/getRelationshipsByTargetSourceType.js
@@ -1,0 +1,20 @@
+const { createSelector } = require('reselect')
+const { values, pipe, map, groupBy, indexBy, prop } = require('ramda')
+
+const getRelationships = require('./getRelationships')
+
+const getRelationshipsByTargetSourceType = createSelector(
+  getRelationships,
+  pipe(
+    values,
+    groupBy(prop('targetId')),
+    map(pipe(
+      groupBy(prop('sourceId')),
+      map(
+        groupBy(prop('relationshipType'))
+      )
+    ))
+  )
+)
+
+module.exports = getRelationshipsByTargetSourceType

--- a/relationships/getters/getRolesByTargetSource.js
+++ b/relationships/getters/getRolesByTargetSource.js
@@ -1,0 +1,18 @@
+const { createSelector } = require('reselect')
+const { map } = require('ramda')
+
+const getRelationshipsByTargetSourceType = require('./getRelationshipsByTargetSourceType')
+
+// TODO combine relationships into roles more intellingently
+// - handle duplicate relationships of same type (how?)
+
+const getRolesByTargetSource = createSelector(
+  getRelationshipsByTargetSourceType,
+  map( // map into target
+    map( // map into source
+      map(() => true) // map into relationshipType
+    )
+  )
+)
+
+module.exports = getRolesByTargetSource


### PR DESCRIPTION
- adds the `getGroupsByMember` getter and parent getters
- this getter is then included in `getAgents`
- also `parseInt` on `agentId`s when included as part of `getMembersByGroup` and `getGroupsByMember`