### PR TITLE
use registration name data when creating profile if present

### DIFF
--- a/authentication/epic.js
+++ b/authentication/epic.js
@@ -70,7 +70,7 @@ function registerEpic (action$, store, deps) {
   return action$.ofType(register.type)
     .switchMap(action => {
       const { payload } = action
-      const { email, password } = payload
+      const { email, password, name } = payload
       const { cid } = action.meta
 
       const createdSuccess$ = action$.ofType(credentials.complete.type).filter(onlyCid).take(1)
@@ -83,7 +83,7 @@ function registerEpic (action$, store, deps) {
       return Rx.Observable.merge(
         Rx.Observable.of(
           registerStart(cid),
-          credentials.create(cid, { email, password })
+          credentials.create(cid, { email, password, name })
         ),
         createdSuccess$
           .withLatestFrom(createdSet$, (success, set) => set.payload.data)

--- a/credentials/service.js
+++ b/credentials/service.js
@@ -86,7 +86,9 @@ function clearRemoteData (hook) {
 function setProfileData (hook) {
   if (!hook.data) return hook
 
-  var name, avatar
+  var name = hook.data.name
+  var avatar
+  delete hook.data.name
 
   if (hook.params.oauth) {
     const remoteProvider = hook.params.oauth.provider


### PR DESCRIPTION
addresses cobuy #370

currently, if a user registers with name / email / password, that name is not saved to their profile created at the same time

NB. must delete `hook.data.name` in `credentials/service` to avoid a postgres constraint violation error.